### PR TITLE
Personal access tokens, loading by folder, custom URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ plugins: [
     options: {
       clientID: 'INSERT_YOUR_CLIENT_IDENTIFIER',
       clientSecret: 'INSERT_YOUR_CLIENT_SECRET',
+      accessToken: 'ALTERNATIVEY_INSERT_PERSONAL_ACCESS_TOKEN',
       userID: 'INSERT_VIMEO_USER_ID_TO_FETCH_VIDEOS',
       searchQuery: 'INSERT_SEARCH_QUERY',               // Optional
+      folderID: '',                                     // Optional
+      tag: '',                                          // Optional
+      url: '',                                          // Optional
       transformer(video) {                              // Optional
         video.newField = 'value';
         return video;
@@ -50,6 +54,19 @@ Client identifier from Vimeo Developer dashboard
 Client secret from Vimeo Developer dashboard
 ```
 
+Note if you require private videos to be returned or need to use the folderID
+filter you should use the accessToken instead.
+
+### accessToken
+
+###### REQUIRED
+
+```
+A personal access token from Vimeo Developer dashboard
+```
+
+Provides support for private videos and loading videos from a folder.
+
 ### userID
 
 ###### REQUIRED
@@ -58,6 +75,35 @@ Client secret from Vimeo Developer dashboard
 User ID that you want to fetch videos from
 (visit Vimeo profile and run window.vimeo.config.profile.app_config.user.id
 on browser console to get the userID)
+```
+
+### folderId
+
+###### OPTIONAL
+
+```
+The ID of a folder in Vimeo to load videos from instead of 'all' videos.
+Requires the use of `accessToken`
+```
+
+### tag
+
+###### OPTIONAL
+
+```
+An optional tag entered on all videos as a custom field to allow for multiple
+instances of this vimeo source on different folders.
+
+Use graphQL to filter by tag
+```
+
+### url
+
+###### OPTIONAL
+
+```
+Use any API endpoint in the Vimeo API by entering the URL. All other selection
+parameters will be ignored.
 ```
 
 ### searchQuery


### PR DESCRIPTION
This plugin was really handy - however I wanted to use it to load videos including private ones from a Vimeo folder.

This MR adds support for:

1. Using personal access tokens so that hidden (access with link only) videos can be listed
2. Support for getting the list of videos from a folder in Vimeo instead of all videos.
3. Added support for a 'url' configuration option to let users craft custom Vimeo API urls that aren't handled by native options.
4. One video in my example list didn't have a picture URI and so added a fence around the regex that processes the URI.
5. Added a 'tag' option so that you can have multiple instances of the source, and then filter for them using graph-ql

All comments welcome.